### PR TITLE
added support for preview and preprod networks

### DIFF
--- a/src/AppTopbar.vue
+++ b/src/AppTopbar.vue
@@ -3,7 +3,7 @@
     <router-link :to="{ name: 'Home' }" class="layout-topbar-logo">
       <img alt="Logo" :src="topbarImage()" />
       <span>AdaView.live</span>
-      <span v-if="!isMainNetwork()" class="test-network-label">&nbsp;test</span>
+      <span v-if="!isMainNetwork()" :style="{'color':getNetworkPalette()}">&nbsp;test</span>
     </router-link>
     <button class="p-link layout-menu-button layout-topbar-button" @click="onMenuToggle">
       <i class="pi pi-bars"></i>
@@ -40,7 +40,7 @@ import { useSettings } from '@/composables/useSettings'
 
 const emit = defineEmits(['menu-toggle', 'topbar-menu-toggle'])
 
-const { isMainNetwork } = useSettings()
+const { isMainNetwork, getNetworkPalette } = useSettings()
 
 const onMenuToggle = (event) => {
   emit('menu-toggle', event)

--- a/src/components/epoch/EpochTipStats.vue
+++ b/src/components/epoch/EpochTipStats.vue
@@ -31,7 +31,7 @@
         <div class="col-12 md:col-6 lg:col-6">
           <Card class="h-full">
             <template #title> {{ L('Slot') }} </template>
-            <template #content> {{ slotNumberInEpoch }} / {{ slotsInAnEpoch }} </template>
+            <template #content> {{ slotNumberInEpoch }} / {{ getNetworkEpochLength() }} </template>
           </Card>
         </div>
       </div>
@@ -41,11 +41,11 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
-import { getSlotsPerEpoch, calculatePercentageToEpoch } from '@/utils/utils'
+import { calculatePercentageToEpoch } from '@/utils/utils'
 import { useFetchTip } from '@/composables/useFetchTip'
 import { useSettings } from '@/composables/useSettings'
 const { tip, incrementAllSlotNbr, fetchTip } = useFetchTip()
-const { isMainNetwork } = useSettings()
+const { isMainNetwork, getNetwork, getNetworkPalette, getNetworkEpochLength } = useSettings()
 
 const incrementSlotTimeMs = import.meta.env.VUE_APP_INCREMENT_SLOT_TIMER_MS || 1000
 let incrementSlotTimer = null
@@ -57,12 +57,11 @@ const props = defineProps({
   },
 })
 
-const slotsInAnEpoch = computed(() => getSlotsPerEpoch())
-const percentageToEpoch = computed(() => calculatePercentageToEpoch(tip.value?.data.slotNumberInEpoch))
+const percentageToEpoch = computed(() => calculatePercentageToEpoch(tip.value?.data.slotNumberInEpoch, getNetworkEpochLength()))
 const slotNumberInEpoch = computed(() => tip.value?.data.slotNumberInEpoch)
 const slotNumber = computed(() => tip.value?.data.slotNumber)
 const epochNumber = computed(() => tip.value?.data.epochNumber)
-const fontColor = computed(() => (isMainNetwork() ? '#ffffff' : '#fcd34d'))
+const fontColor = computed(() => getNetworkPalette())
 
 onMounted(() => {
   fetchTip()
@@ -74,7 +73,7 @@ onBeforeUnmount(() => {
 })
 
 watch(
-  () => isMainNetwork(),
+  () => getNetwork(),
   () => syncSlot(),
 )
 
@@ -98,4 +97,5 @@ const toggle = (event) => {
 .ep-container {
   cursor: pointer;
 }
+
 </style>

--- a/src/components/wallet/transactions/events/StakeDelegationEvent.vue
+++ b/src/components/wallet/transactions/events/StakeDelegationEvent.vue
@@ -5,14 +5,16 @@
       <CopyToClipboardLink :text="event.stakeAddress" :copy-text="event.stakeAddress" break />
     </div>
 
-    <div class="text-500">{{ L('Previous Pool Id') }}:</div>
-    <div>
-      <CopyToClipboardLink :text="event.previousStakePool.poolId" :copy-text="event.previousStakePool.poolId" break />
-    </div>
+    <div v-if="event.previousStakePool">
+      <div class="text-500">{{ L('Previous Pool Id') }}:</div>
+      <div>
+        <CopyToClipboardLink :text="event.previousStakePool.poolId" :copy-text="event.previousStakePool.poolId" break />
+      </div>
 
-    <div class="text-500">{{ L('Previous Pool Ticker') }}:</div>
-    <div>
-      {{ event.previousStakePool.details.ticker }}
+      <div class="text-500">{{ L('Previous Pool Ticker') }}:</div>
+      <div>
+        {{ event.previousStakePool.details.ticker }}
+      </div>
     </div>
 
     <div class="text-500">{{ L('Pool Id') }}:</div>

--- a/src/composables/useFetchTip.js
+++ b/src/composables/useFetchTip.js
@@ -1,14 +1,13 @@
 import { readonly, ref } from 'vue'
 import axios from 'axios'
 import { useSettings } from '@/composables/useSettings'
-import { getSlotsPerEpoch } from '@/utils/utils'
 
 export const useFetchTip = () => {
   const tip = ref(null)
   const loading = ref(false)
   const error = ref(null)
   let abortController = new AbortController()
-  const { getApiUrl } = useSettings()
+  const { getApiUrl, getNetworkEpochLength } = useSettings()
 
   const fetchTip = () => {
     // send an abort signal if there's already a request happening
@@ -52,7 +51,7 @@ export const useFetchTip = () => {
   }
 
   const incrementEpochSlotNbr = () => {
-    if (tip.value?.currentSlot?.slotNumberInEpoch >= getSlotsPerEpoch()) manualEpochRollover()
+    if (tip.value?.currentSlot?.slotNumberInEpoch >= getNetworkEpochLength()) manualEpochRollover()
     if (tip.value?.currentSlot?.slotNumberInEpoch) {
       tip.value.currentSlot.slotNumberInEpoch++
     }

--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -1,17 +1,66 @@
 const mainnetApiRoot = import.meta.env.VITE_MAINNET_API_URL
 const testnetApiRoot = import.meta.env.VITE_TESTNET_API_URL
+const previewApiRoot = import.meta.env.VITE_PREVIEW_API_URL
+const preprodApiRoot = import.meta.env.VITE_PREPROD_API_URL
 
 import { ref } from 'vue'
 
 export const networks = Object.freeze({
   MAIN: 'Mainnet',
   TEST: 'Testnet',
+  PREV: 'Preview',
+  PREP: 'Preprod'
 })
 
 const network = ref(networks.MAIN)
 const setNetwork = (newNetwork) => (network.value = newNetwork)
+const getNetwork = () => network.value
 const isMainNetwork = () => network.value === networks.MAIN
-const getApiUrl = () => (isMainNetwork() ? mainnetApiRoot : testnetApiRoot)
+
+const getApiUrl = () => {
+  if (network.value === networks.TEST) {
+    return testnetApiRoot;
+  }
+  else if (network.value === networks.PREP) {
+    return preprodApiRoot;
+  }
+  else if (network.value == networks.PREV) {
+    return previewApiRoot;
+  }
+  else {
+    return mainnetApiRoot;
+  }
+}
+
+const getNetworkPalette = () => {
+  if (network.value === networks.TEST) {
+    return '#fcd34d';
+  }
+  else if (network.value === networks.PREP) {
+    return '#80b3ff';
+  }
+  else if (network.value === networks.PREV) {
+    return '#e699ff';
+  }
+  else {
+    return '#ffffff';
+  }
+}
+
+const getNetworkEpochLength = () => {
+  if (network.value === networks.TEST) {
+    return 432000;
+  }
+  else if (network.value === networks.PREP) {
+    return 432000;
+  }
+  else if (network.value === networks.PREV) {
+    return 86400;
+  }
+  else {
+    return 432000;
+  }
+}
 
 const langs = Object.freeze([
   { code: 'en', name: 'English', icon: '/images/en.png' },
@@ -28,11 +77,14 @@ const setLang = (newLang) => {
 export const useSettings = () => {
   return {
     isMainNetwork,
+    getNetwork,
     setNetwork,
     network,
     lang,
     setLang,
     langs: Object.keys(langs).map((key) => langs[key]),
     getApiUrl,
+    getNetworkPalette,
+    getNetworkEpochLength
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -77,7 +77,11 @@ router.beforeEach((to, from, next) => {
   from.meta?.scrollPos && (from.meta.scrollPos.top = window.scrollY)
 
   // any route with a :network in it's path will set the global network property
-  to.params.network && setNetwork(to.params.network === networks.MAIN ? networks.MAIN : networks.TEST)
+  to.params.network && setNetwork(
+    to.params.network === networks.MAIN ? networks.MAIN : 
+    to.params.network === networks.TEST ? networks.TEST :
+    to.params.network === networks.PREV ? networks.PREV : 
+    networks.PREP)
 
   // proceed
   next()

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,5 +1,3 @@
-const slotsInAnEpoch = import.meta.env.VITE_NBR_SLOTS_IN_EPOCH
-
 import { TransactionTypes, TransactionTypesById, EventTypes } from '@/utils/constants'
 
 export const formatLovelace = (amount) => {
@@ -29,11 +27,7 @@ export const formatTransaction = (transaction) => {
   }
 }
 
-export const getSlotsPerEpoch = () => {
-  return slotsInAnEpoch
-}
-
-export const calculatePercentageToEpoch = (slotNumber) => {
+export const calculatePercentageToEpoch = (slotNumber, slotsInAnEpoch) => {
   if (slotNumber == null || slotNumber < 0) return 0
   return parseFloat(((slotNumber / slotsInAnEpoch) * 100).toFixed(2))
 }


### PR DESCRIPTION
Added some additional functions to the settings for network specific customizations:

palette -- currently contains a simple font color
epoch length -- returns the epoch length for a given network to calculate percentages

I believe the code works, but could use some refactoring to create an object for each network with the fields:
url, palette, epoch lenght, name, etc.   this would make it easier to add new networks in future if needed.  

fixes #7